### PR TITLE
Fixes name of mob disconnecting from nameplate (Neat mod)

### DIFF
--- a/config/neat-client.toml
+++ b/config/neat-client.toml
@@ -7,7 +7,7 @@
 	"Plate Size (Boss)" = 50
 	"Show Max HP" = false
 	"Max Distance" = 24
-	"Show Attributes" = false
+	"Show Attributes" = true
 	"Show Current HP" = false
 	"Show Debug Info with F3" = true
 	"Background Padding" = 2


### PR DESCRIPTION
Currently, the Neat mod's name of mobs breaks off of the nameplate and floats around once the player moves somewhat away and moves their mouse around. This was demonstrated by multiple players saying they've seen it and on both of my computers.

This is, seemingly, due to all elements of the nameplate being disabled OR the Show Attributes element somehow breaking it. Either way, this only adds a small flesh or bone icon depending on the type of mob on top of the health bar and shouldn't have any other compatibility issues.

The bug:
https://cdn.discordapp.com/attachments/726729792547717181/1026208117031174194/IMG_4107.jpg 